### PR TITLE
Support tuple-like objects, support int coordinates

### DIFF
--- a/tests/test_vw.py
+++ b/tests/test_vw.py
@@ -8,6 +8,7 @@
 # http://www.opensource.org/licenses/MIT-license
 # Copyright (c) 2015, fitnr <contact@fakeisthenewreal.org>
 import json
+import numpy as np
 import unittest
 import visvalingamwyatt as vw
 from visvalingamwyatt import cli
@@ -55,3 +56,44 @@ class TestCase(unittest.TestCase):
         a = vw.simplify(coordinates)
         assert a[0] == [0, 0, 0]
         assert len(a) <= len(coordinates)
+
+    def testSimplifyTupleLike(self):
+        class Point(object):
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+            def __iter__(self):
+                yield self.x
+                yield self.y
+
+        # coordinates are in the shape
+        #
+        #     c
+        #   b  d
+        #  a    e
+        #
+        # so b and d are eliminated
+
+        a, b, c, d, e = Point(0, 0), Point(1, 1), Point(2, 2), Point(3, 1), Point(4, 0)
+        input = [a, b, c, d, e]
+        expected_output = np.array([a, c, e])
+
+        actual_output = vw.simplify(input, threshold=0.001)
+        assert np.array_equal(actual_output, expected_output)
+
+    def testSimplifyIntegerCoords(self):
+        # coordinates are in the shape
+        #
+        #     c
+        #   b  d
+        #  a    e
+        #
+        # so b and d are eliminated
+
+        a, b, c, d, e = (0, 0), (1, 1), (2, 2), (3, 1), (4, 0)
+        input = [a, b, c, d, e]
+        expected_output = np.array([a, c, e])
+
+        actual_output = vw.simplify(input, threshold=0.001)
+        assert np.array_equal(actual_output, expected_output)

--- a/visvalingamwyatt/visvalingamwyatt.py
+++ b/visvalingamwyatt/visvalingamwyatt.py
@@ -98,7 +98,8 @@ class Simplifier(object):
         '''Initialize with points. takes some time to build
         the thresholds but then all threshold filtering later
         is ultra fast'''
-        self.pts = np.array(pts)
+        self.pts_in = np.array(pts)
+        self.pts = np.array(tuple(map(float, pt)) for pt in pts)
         self.thresholds = self.build_thresholds()
         self.ordered_thresholds = sorted(self.thresholds, reverse=True)
 
@@ -195,13 +196,13 @@ class Simplifier(object):
             return self.by_ratio(ratio)
 
     def by_threshold(self, threshold):
-        return self.pts[self.thresholds >= threshold]
+        return self.pts_in[self.thresholds >= threshold]
 
     def by_number(self, n):
         try:
             threshold = self.ordered_thresholds[int(n)]
         except IndexError:
-            return self.pts
+            return self.pts_in
 
         return self.by_threshold(threshold)
 

--- a/visvalingamwyatt/visvalingamwyatt.py
+++ b/visvalingamwyatt/visvalingamwyatt.py
@@ -99,7 +99,7 @@ class Simplifier(object):
         the thresholds but then all threshold filtering later
         is ultra fast'''
         self.pts_in = np.array(pts)
-        self.pts = np.array(tuple(map(float, pt)) for pt in pts)
+        self.pts = np.array([tuple(map(float, pt)) for pt in pts])
         self.thresholds = self.build_thresholds()
         self.ordered_thresholds = sorted(self.thresholds, reverse=True)
 


### PR DESCRIPTION
Allow the user to pass an array of tuple-like objects (i.e. objects that can be
passed to tuple()) instead of normal tuples. For example, if the user defines
a class Point, they can call

    vw.simplify([Point(1, 2), Point(3, 4), ...])

Also support points with integer coordinates, by casting the input coordinates
to floats.