### PR TITLE
Fix internal logic

### DIFF
--- a/src/visvalingamwyatt/visvalingamwyatt.py
+++ b/src/visvalingamwyatt/visvalingamwyatt.py
@@ -215,7 +215,18 @@ class Simplifier:
         # return the first n points since by_threshold
         # could return more points if the threshold is the same
         # for some points
-        return self.by_threshold(threshold)[:n]
+
+        # sort point indices by threshold
+        idx = list(range(len(self.pts)))
+        sorted_indices = sorted(zip(idx, self.thresholds), reverse=True, key=lambda x: x[1])
+
+        # grab first n indices
+        sorted_indices = sorted_indices[:n]
+
+        # re-sort by index
+        final_indices = sorted( [x[0] for x in sorted_indices] )
+
+        return self.pts[final_indices]
 
     def by_ratio(self, r):
         if r <= 0 or r > 1:


### PR DESCRIPTION
Fix internal logic in function `by_number` to ensure that the highest-threshold _n_ points are returned (preserving order) instead of simply the first _n_ points that meet the threshold (previous code can omit higher-threshold points that should have been retained)

Sample case:  using this test polygon:
`test_contour = [ (5,2),(6,2),(6,3),(8,4),(6,5),(6,6),(5,6),(4,8),(3,6),(2,6),(2,5),(0,4),(2,3),(2,2),(3,2),(4,0),(5,2)]`

original code produces these outputs:

```
simplifier = Simplifier(test_contour)
simplifier.simplify(ratio=0.8)
```
returns
`[[5, 2],[6, 2],[6, 3],[8, 4],[6, 5],[6, 6],[5, 6],[4, 8],[3, 6],[2, 6],[2, 5],[0, 4],[2, 3]] `

which is cutting off one large area, and

```
simplifier = Simplifier(test_contour)
simplifier.simplify(ratio=0.6)
```
returns
`[[5, 2],[6, 2],[6, 3],[8, 4],[6, 5],[6, 6],[5, 6],[4, 8],[3, 6],[2, 6]]`

which is cutting off two large areas.

With the modified code, the results are

`[[5, 2],[6, 2],[6, 3],[8, 4],[6, 5],[6, 6],[5, 6],[4, 8],[2, 5],[0, 4],[3, 2],[4, 0],[5, 2]]`  (ratio = 0.8)
and
`[[5, 2],[6, 2],[8, 4],[5, 6],[4, 8],[2, 5],[0, 4],[3, 2],[4, 0],[5, 2]]` (ratio = 0.6)

Plotting the before and after point sets will demonstrate the changes most clearly.  The results from after the change correctly discard the lower-threshold triangles, better preserving the original shape.